### PR TITLE
Fix: Update FFmpeg and address video loading issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,7 +202,6 @@
   <body>
     <div id="videoReactContainer" class="ui-widget-content">
       <video id="videoReact" draggable="true" style="display:block;">
-        <source src="" type="video/mp4; codecs=hevc,mp4a.40.2">
         <source src="" type="video/mp4">
       </video>
       <div id="videoReactYoutube" style="width:100%;height:calc(100% - 40px);display:none;"></div>
@@ -216,7 +215,6 @@
     </div>
     <div id="videoBaseContainer" style="width:100%;height:100%;position:relative;">
       <video id="videoBaseLocal" style="display:block;">
-        <source src="" type="video/mp4; codecs=hevc,mp4a.40.2">
         <source src="" type="video/mp4">
       </video>
       <div id="videoBaseYoutube" style="width:100%;height:100%;display:none;"></div>

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,4 +1,4 @@
-import { createFFmpeg, fetchFile } from 'https://unpkg.com/@ffmpeg/ffmpeg@0.10.0/dist/ffmpeg.min.js';
+import { createFFmpeg, fetchFile } from 'https://unpkg.com/@ffmpeg/ffmpeg@0.12.6/dist/ffmpeg.min.js';
 const ffmpeg = createFFmpeg({ log: true });
 
 function secondsToTime(seconds, prec = 1) {


### PR DESCRIPTION
- Updates @ffmpeg/ffmpeg to v0.12.6 in js/utils.js. This resolves an error where `fetchFile` was not found, as it was not available in the previously used version (0.10.0). This change enables video transcoding for unsupported codecs.

- Removes HEVC-specific <source> tags from index.html. The explicit `codecs=hevc` source tags were causing console warnings ("type not supported") on browsers without HEVC support. Removing them allows the browser to fall back to the general video/mp4 source, and relies on the now-functional ffmpeg transcoding for other unsupported formats. This provides a cleaner console experience and proper handling of various video codecs.