### PR TITLE
Fix: Change CDN for FFmpeg to resolve MIME type errors

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -1,4 +1,4 @@
-import { createFFmpeg, fetchFile } from 'https://unpkg.com/@ffmpeg/ffmpeg@0.12.6/dist/ffmpeg.min.js';
+import { createFFmpeg, fetchFile } from 'https://esm.sh/@ffmpeg/ffmpeg@0.12.6';
 const ffmpeg = createFFmpeg({ log: true });
 
 function secondsToTime(seconds, prec = 1) {


### PR DESCRIPTION
- Modifies js/utils.js to import @ffmpeg/ffmpeg from esm.sh instead of unpkg.

  The previous unpkg URL for @ffmpeg/ffmpeg@0.12.6/dist/ffmpeg.min.js was resulting in "disallowed MIME type ('text/plain')" and CORS errors, preventing ffmpeg.wasm from loading.

  Using https://esm.sh/@ffmpeg/ffmpeg@0.12.6 should provide a more reliable ES module-compatible version and resolve these loading issues.