### PR TITLE
Fix: Refine esm.sh URL for FFmpeg import

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -1,4 +1,4 @@
-import { createFFmpeg, fetchFile } from 'https://esm.sh/@ffmpeg/ffmpeg@0.12.6';
+import { createFFmpeg, fetchFile } from 'https://esm.sh/@ffmpeg/ffmpeg@0.12.6/dist/ffmpeg.min.js';
 const ffmpeg = createFFmpeg({ log: true });
 
 function secondsToTime(seconds, prec = 1) {


### PR DESCRIPTION
- I've modified js/utils.js to import @ffmpeg/ffmpeg from a specific file path on esm.sh: https://esm.sh/@ffmpeg/ffmpeg@0.12.6/dist/ffmpeg.min.js

  The previous attempt to use https://esm.sh/@ffmpeg/ffmpeg@0.12.6 resulted in an error indicating that 'fetchFile' was not a named export. This change targets the distributed minified file directly, which should correctly provide all necessary exports, including 'fetchFile', while leveraging esm.sh for proper ES module delivery with the correct MIME type.